### PR TITLE
Allow setting options via cli arguments

### DIFF
--- a/bear_export_sync.py
+++ b/bear_export_sync.py
@@ -36,28 +36,60 @@ or leave list empty for all notes: `limit_export_to_tags = []`
 * Or export as textbundles with images included 
 '''
 
-make_tag_folders = True  # Exports to folders using first tag only, if `multi_tag_folders = False`
-multi_tag_folders = True  # Copies notes to all 'tag-paths' found in note!
-                          # Only active if `make_tag_folders = True`
-hide_tags_in_comment_block = True  # Hide tags in HTML comments: `<!-- #mytag -->`
+import argparse
+
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+parser = argparse.ArgumentParser(description='Markdown export from Bear sqlite database.')
+
+parser.add_argument("--make_tag_folders", type=str2bool, nargs='?', const=True,
+                    default=True, help="(Default: True) Exports to folders using first tag only, if `multi_tag_folders = False`")
+
+parser.add_argument("--multi_tag_folders", type=str2bool, nargs='?', const=True,
+                    default=True, help="(Default: True) Copies notes to all 'tag-paths' found in note! Only active if `make_tag_folders = True`")
+
+parser.add_argument("--hide_tags_in_comment_block", type=str2bool, nargs='?', const=True,
+                    default=True, help="(Default: True) Hide tags in HTML comments: `<!-- #mytag -->`")
 
 # The following two lists are more or less mutually exclusive, so use only one of them.
 # (You can use both if you have some nested tags where that makes sense)
-# Also, they only work if `make_tag_folders = True`.
-only_export_these_tags = []  # Leave this list empty for all notes! See below for sample
-# only_export_these_tags = ['bear/github', 'writings'] 
-no_export_tags = []  # If a tag in note matches one in this list, it will not be exported.
-# no_export_tags = ['private', '.inbox', 'love letters', 'banking'] 
+parser.add_argument("--only_export_these_tags", nargs='*',
+                    default=[], help="(Default: '') Example: \"--only_export_these_tags 'bear/github' 'writings'\". Leave this list empty for all notes! Works only if `make_tag_folders = True`")
+parser.add_argument("--no_export_tags", nargs='*',
+                    default=[], help="(Default: '') Example: \"--no_export_tags 'private' '.inbox' 'love letters' 'banking'\". If a tag in note matches one in this list, it will not be exported.")
 
-export_as_textbundles = True  # Exports as Textbundles with images included
-export_as_hybrids = True  # Exports as .textbundle only if images included, otherwise as .md
-                          # Only used if `export_as_textbundles = True`
-export_image_repository = False  # Export all notes as md but link images to 
-                                 # a common repository exported to: `assets_path` 
-                                 # Only used if `export_as_textbundles = False`
+parser.add_argument("--export_as_textbundles", type=str2bool, nargs='?', const=True,
+                    default=False, help="(Default: False) Exports as Textbundles with images included")
 
-my_sync_service = 'Dropbox'  # Change 'Dropbox' to 'Box', 'Onedrive',
-    # or whatever folder of sync service you need.
+parser.add_argument("--export_as_hybrids", type=str2bool, nargs='?', const=True,
+                    default=True, help="(Default: True) Exports as .textbundle only if images included, otherwise as .md. Only used if `export_as_textbundles = True`")
+
+parser.add_argument("--export_image_repository", type=str2bool, nargs='?', const=True,
+                    default=False, help="(Default: False) Export all notes as md but link images to a common repository exported to: `assets_path`. Only used if `export_as_textbundles = False`")
+
+parser.add_argument("--my_sync_service", nargs='?', const=True,
+                    default="Dropbox", help="(Default: Dropbox) Change 'Dropbox' to 'Box', 'Onedrive', or whatever folder of sync service you need.")
+
+parser.add_argument("--set_logging_on", type=str2bool, nargs='?', const=True,
+                    default=True, help="(Default: True)")
+
+args = parser.parse_args()
+make_tag_folders = args.make_tag_folders
+multi_tag_folders = args.multi_tag_folders
+hide_tags_in_comment_block = args.hide_tags_in_comment_block
+only_export_these_tags = args.only_export_these_tags
+no_export_tags = args.no_export_tags
+export_as_textbundles = args.export_as_textbundles
+export_as_hybrids = args.export_as_hybrids
+export_image_repository = args.export_image_repository
+my_sync_service = args.my_sync_service
+set_logging_on = args.set_logging_on
 
 # NOTE! Your user 'HOME' path and '/BearNotes' is added below!
 # NOTE! So do not change anything below here!!!
@@ -74,8 +106,6 @@ import fnmatch
 import json
 
 HOME = os.getenv('HOME', '')
-
-set_logging_on = True
 
 # NOTE! if 'BearNotes' is left blank, all other files in my_sync_service will be deleted!! 
 export_path = os.path.join(HOME, my_sync_service, 'BearNotes')

--- a/bear_import.py
+++ b/bear_import.py
@@ -18,12 +18,32 @@ github/rovest, rorves@twitter
 * Or for import of nested groups and sheets from Ulysses, images and keywords included.
 '''
 
-my_sync_service = 'Dropbox'  # Change 'Dropbox' to 'Box', 'Onedrive',
-    # or whatever folder of sync service you need.
-    # Your user "Home" folder is added below.
+import argparse
 
-use_filename_as_title = False  # Set to `True` if importing Simplenotes synced with nvALT.
-set_logging_on = True
+def str2bool(v):
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
+parser = argparse.ArgumentParser(description='Markdown import to Bear from folder.')
+
+parser.add_argument("--my_sync_service", nargs='?', const=True,
+                    default="Dropbox", help="(Default: Dropbox) Change 'Dropbox' to 'Box', 'Onedrive', or whatever folder of sync service you need.")
+# Your user "Home" folder is added below.
+
+parser.add_argument("--use_filename_as_title", type=str2bool, nargs='?', const=True,
+                    default=False, help="(Default: False) Set to `True` if importing Simplenotes synced with nvALT.")
+
+parser.add_argument("--set_logging_on", type=str2bool, nargs='?', const=True,
+                    default=True, help="(Default: True)")
+
+args = parser.parse_args()
+my_sync_service = args.my_sync_service
+use_filename_as_title = args.use_filename_as_title
+set_logging_on = args.set_logging_on
 
 # This tag is added for convenience (easy deletion of imported notes they are not wanted.)
 # (Easier to delete one tag, than finding a bunch of tagless imported notes.)


### PR DESCRIPTION
As a bonus, it adds a help output, helping out with https://github.com/rovest/Bear-Markdown-Export/issues/3:

```
$ python bear_export_sync.py --help
usage: bear_export_sync.py [-h] [--sync [SYNC]]
                           [--make_tag_folders [MAKE_TAG_FOLDERS]]
                           [--multi_tag_folders [MULTI_TAG_FOLDERS]]
                           [--hide_tags_in_comment_block [HIDE_TAGS_IN_COMMENT_BLOCK]]
                           [--only_export_these_tags [ONLY_EXPORT_THESE_TAGS [ONLY_EXPORT_THESE_TAGS ...]]]
                           [--no_export_tags [NO_EXPORT_TAGS [NO_EXPORT_TAGS ...]]]
                           [--export_as_textbundles [EXPORT_AS_TEXTBUNDLES]]
                           [--export_as_hybrids [EXPORT_AS_HYBRIDS]]
                           [--export_image_repository [EXPORT_IMAGE_REPOSITORY]]
                           [--my_sync_service [MY_SYNC_SERVICE]]
                           [--set_logging_on [SET_LOGGING_ON]]

Markdown export from Bear sqlite database.

optional arguments:
  -h, --help            show this help message and exit
  --sync [SYNC]         (Default: True) Sync external updates back into Bear
  --make_tag_folders [MAKE_TAG_FOLDERS]
                        (Default: True) Exports to folders using first tag
                        only, if `multi_tag_folders = False`
  --multi_tag_folders [MULTI_TAG_FOLDERS]
                        (Default: True) Copies notes to all 'tag-paths' found
                        in note! Only active if `make_tag_folders = True`
  --hide_tags_in_comment_block [HIDE_TAGS_IN_COMMENT_BLOCK]
                        (Default: True) Hide tags in HTML comments: `<!--
                        #mytag -->`
  --only_export_these_tags [ONLY_EXPORT_THESE_TAGS [ONLY_EXPORT_THESE_TAGS ...]]
                        (Default: '') Example: "--only_export_these_tags
                        'bear/github' 'writings'". Leave this list empty for
                        all notes! Works only if `make_tag_folders = True`
  --no_export_tags [NO_EXPORT_TAGS [NO_EXPORT_TAGS ...]]
                        (Default: '') Example: "--no_export_tags 'private'
                        '.inbox' 'love letters' 'banking'". If a tag in note
                        matches one in this list, it will not be exported.
  --export_as_textbundles [EXPORT_AS_TEXTBUNDLES]
                        (Default: False) Exports as Textbundles with images
                        included
  --export_as_hybrids [EXPORT_AS_HYBRIDS]
                        (Default: True) Exports as .textbundle only if images
                        included, otherwise as .md. Only used if
                        `export_as_textbundles = True`
  --export_image_repository [EXPORT_IMAGE_REPOSITORY]
                        (Default: False) Export all notes as md but link
                        images to a common repository exported to:
                        `assets_path`. Only used if `export_as_textbundles =
                        False`
  --my_sync_service [MY_SYNC_SERVICE]
                        (Default: Dropbox) Change 'Dropbox' to 'Box',
                        'Onedrive', or whatever folder of sync service you
                        need.
  --set_logging_on [SET_LOGGING_ON]
                        (Default: True)
```

```
$ python bear_import.py --help
usage: bear_import.py [-h] [--my_sync_service [MY_SYNC_SERVICE]]
                      [--use_filename_as_title [USE_FILENAME_AS_TITLE]]
                      [--set_logging_on [SET_LOGGING_ON]]

Markdown import to Bear from folder.

optional arguments:
  -h, --help            show this help message and exit
  --my_sync_service [MY_SYNC_SERVICE]
                        (Default: Dropbox) Change 'Dropbox' to 'Box',
                        'Onedrive', or whatever folder of sync service you
                        need.
  --use_filename_as_title [USE_FILENAME_AS_TITLE]
                        (Default: False) Set to `True` if importing
                        Simplenotes synced with nvALT.
  --set_logging_on [SET_LOGGING_ON]
                        (Default: True)
```